### PR TITLE
chore: raise minimum Gradle version to 5.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will upload the plugin to Nexus repository
 ## Requirements
 
 - JDK 8
-- Gradle 5.1.1
+- Gradle 5.6.4
 
 ## Usage
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/kotlin/com/ekino/oss/gradle/plugin/docker/GradleVersionsCompatibilityTest.kt
+++ b/src/test/kotlin/com/ekino/oss/gradle/plugin/docker/GradleVersionsCompatibilityTest.kt
@@ -14,7 +14,7 @@ class GradleVersionsCompatibilityTest {
     @TempDir
     lateinit var tempDir: File
 
-    @ValueSource(strings = ["5.1.1", "5.4.1", "5.6.4", "6.2"])
+    @ValueSource(strings = ["5.6.4", "6.2.2"])
     @ParameterizedTest(name = "{0}")
     @DisplayName("Should work with Gradle version")
     fun shouldWorkInGradleVersion(gradleVersion: String) {


### PR DESCRIPTION
Fix: https://github.com/ekino/gradle-docker-plugin/issues/16